### PR TITLE
Improve Error Logging: issues/33

### DIFF
--- a/server/coin-gecko-scraper.js
+++ b/server/coin-gecko-scraper.js
@@ -1,7 +1,7 @@
 const moment = require('moment');
 const axios = require('axios');
 const { DISCORD_WEBHOOK_URLS } = require('./config');
-const { notifyOnDiscord } = require('./common-functions');
+const { notifyOnDiscord, logError } = require('./common-functions');
 
 module.exports = class CoinGeckoScraper {
     constructor() {
@@ -37,8 +37,7 @@ module.exports = class CoinGeckoScraper {
                 this.checkNewCoin()
             }
             catch (error) {
-                let errorTiming = moment().toString();
-                console.log(`${error} at ${errorTiming}`)
+                logError(error);
             }
 
         }, 5000);

--- a/server/coin-scraper.js
+++ b/server/coin-scraper.js
@@ -1,7 +1,7 @@
 const moment = require('moment');
 const axios = require('axios')
 const { CMC_API_KEY, DISCORD_WEBHOOK_URLS } = require('./config');
-const { notifyOnDiscord } = require('./common-functions');
+const { notifyOnDiscord, logError } = require('./common-functions');
 
 module.exports = class CoinScraper {
   constructor() {
@@ -74,7 +74,7 @@ module.exports = class CoinScraper {
       });
       this.updateDictionary();
     } catch(error) {
-      this.logError(error);
+      logError(error);
     }
   }
 
@@ -89,13 +89,8 @@ module.exports = class CoinScraper {
         this.flagNewArrivals();
       }, interval);
     } catch (err) {
-      this.logError(err);
+      logError(err);
     }
   }
 
-  logError(error) {
-    let errorTiming = moment().toString();
-    console.log(error);
-    console.log(` at ${errorTiming}`);
-  }
 };

--- a/server/common-functions.js
+++ b/server/common-functions.js
@@ -1,4 +1,5 @@
 const rp = require('request-promise');
+const moment = require('moment');
 
 const notifyOnDiscord = (msg, discordWebhookUrl) => {
     const requestOptions = {
@@ -16,6 +17,13 @@ const notifyOnDiscord = (msg, discordWebhookUrl) => {
     });
 }
 
+const logError = (error) => {
+    let errorTiming = moment().toString();
+    console.log(error);
+    console.log(`at ${errorTiming}`);
+}
+
 module.exports = {
-    notifyOnDiscord
+    notifyOnDiscord,
+    logError
 }


### PR DESCRIPTION
## Problem
#33 

## Solution
Read commit msgs.
1. Separated error object and time object logging (seems they are compacted when concatenated with each other).
2. Refactored `logError()` method by moving it to `common-functions.js` file and reused it in both scrapers.

Closes #33 