### PR TITLE
CMC api started serving listing in opposite order (oldest first) with 'asc' sort direction: issues/40

### DIFF
--- a/server/coin-scraper.js
+++ b/server/coin-scraper.js
@@ -22,7 +22,7 @@ module.exports = class CoinScraper {
           'start': '1',
           'limit': '200',
           'sort': 'date_added',
-          'sort_dir': 'asc',
+          'sort_dir': 'desc',
           'aux': 'date_added,platform'
         },
         headers: {


### PR DESCRIPTION
## Problem
#40 

## Solution
Inverted sort direction to fix the issue (probably at CMC's end) that caused the /listings/latest api data to be served in oldest-first order with 'asc' direction although it used to be most recent first with 'asc' sort dir earlier