### PR TITLE
Add a hardcoded log at the beginning of catch block of coin gecko polling error handler: issues/50

### DIFF
--- a/server/coin-gecko-scraper.js
+++ b/server/coin-gecko-scraper.js
@@ -47,6 +47,7 @@ module.exports = class CoinGeckoScraper {
                 this.interval = 5000;
                 setTimeout(callApi, this.interval);
             } catch (error) {
+                console.log(`===== catch block of CG polling service ======`);
                 if (error.response === undefined) {
                     logError('Response is undefined');
                     setTimeout(() => {


### PR DESCRIPTION
## Problem #50 

## Solution
Added a hardcoded log at the start of polling error handler, in the hope of finding of whether the error handler is activated by the last call after which the polling service stops working and vanishes into thin air.