### PR TITLE
added a log on api call returning with success following a failed api…

### DIFF
--- a/server/coin-gecko-scraper.js
+++ b/server/coin-gecko-scraper.js
@@ -32,6 +32,9 @@ module.exports = class CoinGeckoScraper {
                     timeout: 20000 // 20 seconds
                 };
                 let response = await axios(config);
+                if(fromCatchBlock) {
+                    console.error('Polled successfully after error');
+                }
                 updateJsonFile('gecko');
                 this.incomingCoins = response.data || [];
                 const dictionarySize = Object.keys(this.storedCoinList).length;


### PR DESCRIPTION
## Problem #50 

## Solution
Added a log on api call returning with success following a failed api call in order to check if the api call that seems to vanish (takes the CG scraper with it) returns with success (it does not seem to return with failure cuz the error logs do not show anything after the mysterious vanishing api call goes out).