### PR TITLE
Log everytime the next polling call is scheduling via setTimeout from the success block of the method handling polling i-e callApi() method: issues/50

### DIFF
--- a/server/coin-gecko-scraper.js
+++ b/server/coin-gecko-scraper.js
@@ -57,6 +57,7 @@ module.exports = class CoinGeckoScraper {
                     this.checkNewCoin()
                 }
                 this.interval = 5000;
+                console.log(`calling setTimeout from try block of callApi() method`);
                 setTimeout(callApi, this.interval);
             } catch (error) {
                 console.error(`===== catch block of CG polling service ======`);


### PR DESCRIPTION
## Problem #50 

## Solution
Diagnosis, and to diagnose we want to find out exactly what was called before the polling service vanishes.
Added a log before every call to setTimeout from try block of the method, `callApi()`, used to poll coin-gecko servers.