### PR TITLE
Reduce polling interval to every 12 seconds i-e 5 calls per minute

### DIFF
--- a/server/coin-gecko-scraper.js
+++ b/server/coin-gecko-scraper.js
@@ -3,12 +3,13 @@ const axios = require('axios');
 const { TELEGRAM_WEBHOOK_URLS, DISCORD_WEBHOOK_URLS } = require('./config');
 const { notifyOnTelegram, notifyOnDiscord, logError, updateJsonFile } = require(
     './common-functions');
+const { COIN_GECKO_INTERVAL } = require('./constants');
 
 module.exports = class CoinGeckoScraper {
     constructor() {
         this.incomingCoins = [];
         this.storedCoinList = {};
-        this.interval = 5000;
+        this.interval = COIN_GECKO_INTERVAL;
         this.telegramWebhookKey = 'TelegramBot';
         this.discordWebhookKey = 'CGBajwaBot';
         if (process.env.NODE_ENV === 'dev') {
@@ -56,8 +57,8 @@ module.exports = class CoinGeckoScraper {
                     }
                     this.checkNewCoin()
                 }
-                this.interval = 5000;
-                console.log(`calling setTimeout from try block of callApi() method`);
+                this.interval = COIN_GECKO_INTERVAL;
+                console.error(`calling setTimeout from try block of callApi() method`);
                 setTimeout(callApi, this.interval);
             } catch (error) {
                 console.error(`===== catch block of CG polling service ======`);

--- a/server/constants.js
+++ b/server/constants.js
@@ -1,5 +1,7 @@
 const CUTOFF_DATE = '2021/04/25';
+const COIN_GECKO_INTERVAL = 12000;
 
 module.exports = {
-  CUTOFF_DATE
+  CUTOFF_DATE,
+  COIN_GECKO_INTERVAL
 };


### PR DESCRIPTION
## Problem #50 

## Solution
Reduce polling interval to every 12 seconds i-e 5 calls per minute since https://support.coingecko.com/help/can-i-use-coingecko-data-and-screenshots-for-my-website-book-etc states 
```
The /coins/list endpoint has a rate limit of only 5 requests/minute
```